### PR TITLE
Fix usage of log.Fatalln, which exits the program

### DIFF
--- a/aws-es-proxy.go
+++ b/aws-es-proxy.go
@@ -120,7 +120,7 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	requestStarted := time.Now()
 	dump, err := httputil.DumpRequest(r, true)
 	if err != nil {
-		log.Fatalln("error while dumping request. Error: ", err.Error())
+		log.Println("error while dumping request. Error: ", err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -132,7 +132,7 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	req, err := http.NewRequest(r.Method, ep.String(), r.Body)
 	if err != nil {
-		log.Fatalln("error creating new request. ", err.Error())
+		log.Println("error creating new request. ", err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -151,7 +151,7 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		log.Fatalln(err.Error())
+		log.Println(err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -172,8 +172,9 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Send response back to requesting client
 	body := bytes.Buffer{}
 	if _, err := io.Copy(&body, resp.Body); err != nil {
-		log.Fatalln(err.Error())
+		log.Println(err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 	w.WriteHeader(resp.StatusCode)
 	w.Write(body.Bytes())
@@ -323,7 +324,6 @@ func main() {
 
 	if err = p.parseEndpoint(); err != nil {
 		log.Fatalln(err)
-		os.Exit(1)
 	}
 
 	if p.logtofile {


### PR DESCRIPTION
`log.Fatalln` calls `os.Exit(1)` internally so no code after it will execute. This means instead of `http.Error` getting called the program would exit in cases where the ES domain is temporarily unreachable.