### PR TITLE
add credential file mapping example for docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ There is an official docker image avaiable for aws-es-proxy. To run the image:
 docker run --rm -it abutaha/aws-es-proxy
 
 # Runs with custom command/args
-docker run --rm -it abutaha/aws-es-proxy ./aws-es-proxy -endpoint https://dummy-host.ap-southeast-2.es.amazonaws.com
+docker run --rm -p 9200:9200 -it abutaha/aws-es-proxy ./aws-es-proxy -endpoint https://dummy-host.ap-southeast-2.es.amazonaws.com
+
+# Use aws credentials file; only default profile is supported
+docker run --rm -p 9200:9200 -v `pwd`/aws-es-proxy-credentials:/root/.ssh/credentials -it abutaha/aws-es-proxy ./aws-es-proxy -endpoint https://dummy-host.ap-southeast-2.es.amazonaws.com
 ```
 
 To expose a port number other than the default 9200, pass an environment variable of `PORT_NUM` to docker with the port number you wish to expose for your service.
@@ -138,3 +141,4 @@ To expose a port number other than the default 9200, pass an environment variabl
 After you run *aws-es-proxy*, you can now open your Web browser on [http://localhost:9200](http://localhost:9200). Everything should be working as you have your own instance of ElasticSearch running on port 9200.
 
 To access Kibana, use [http://localhost:9200/_plugin/kibana/](http://localhost:9200/_plugin/kibana/)
+


### PR DESCRIPTION
I couldn't tell if the credential file was supported in Docker, I had to read and test to verify. So I'm including an example of that.

Also adding the port mapping for the 9200 port to the previous example.