### PR TITLE
403 responses are not returned to browser

### DIFF
--- a/aws-es-proxy.go
+++ b/aws-es-proxy.go
@@ -160,7 +160,6 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// AWS credentials expired, need to generate fresh ones
 		if resp.StatusCode == 403 {
 			p.credentials = nil
-			return
 		}
 	}
 


### PR DESCRIPTION
The `return` statement on the 403 status response causes the browser to NOT get the proxied response.

For example, a bad credential:

Before:
```
➜  ~ curl 'http://localhost:9200/_plugin/kibana/app/kibana' -vvv
*   Trying ::1...
* TCP_NODELAY set
* Connection failed
* connect to ::1 port 9200 failed: Connection refused
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 9200 (#0)
> GET /_plugin/kibana/app/kibana HTTP/1.1
> Host: localhost:9200
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Fri, 09 Nov 2018 22:38:49 GMT
< Content-Length: 0
<
* Connection #0 to host localhost left intact
```

After:
```
➜  ~ curl 'http://localhost:9200/_plugin/kibana/app/kibana' -vvv
*   Trying ::1...
* TCP_NODELAY set
* Connection failed
* connect to ::1 port 9200 failed: Connection refused
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 9200 (#0)
> GET /_plugin/kibana/app/kibana HTTP/1.1
> Host: localhost:9200
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 403 Forbidden
< Access-Control-Allow-Origin: *
< Content-Length: 72
< Content-Type: application/json
< Date: Fri, 09 Nov 2018 22:39:10 GMT
< X-Amzn-Requestid: 46a72880-e470-11e8-9057-8107a8310d43
<
* Connection #0 to host localhost left intact
{"Message":"User: anonymous is not authorized to perform: es:ESHttpGet"}%
```