### PR TITLE
Update golang references to 1.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ brew install aws-es-proxy
 ### Build from Source
 
 #### Dependencies:
-* go1.11+
+* go1.14+
 
 ```sh
-#requires go1.11
+#requires go1.14
 go build github.com/abutaha/aws-es-proxy
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/abutaha/aws-es-proxy
 
-go 1.13
+go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.30.4


### PR DESCRIPTION
I saw Dockerfile is already using go 1.14, thus updated all the golang references to go1.14.

Also the brew formula already shipped with latest golang (https://github.com/Homebrew/homebrew-core/pull/52702)