### PR TITLE
Issue #70 - support the kbn-xsrf header

### DIFF
--- a/aws-es-proxy.go
+++ b/aws-es-proxy.go
@@ -372,7 +372,8 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // Recent versions of ES/Kibana require
-// "kbn-version" and "content-type: application/json"
+// "content-type: application/json" and
+// either "kbn-version" or "kbn-xsrf"
 // headers to exist in the request.
 // If missing requests fails.
 func addHeaders(src, dest http.Header) {
@@ -382,6 +383,10 @@ func addHeaders(src, dest http.Header) {
 
 	if val, ok := src["Content-Type"]; ok {
 		dest.Add("Content-Type", val[0])
+	}
+
+	if val, ok := src["Kbn-Xsrf"]; ok {
+		dest.Add("Kbn-Xsrf", val[0])
 	}
 }
 


### PR DESCRIPTION
fixes #70 

it adds support for header kbn-xsrf when using kibana APIs through aws-es-proxy.