### PR TITLE
Issue #71 - add environment variable support for elasticsearch endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,18 @@ export AWS_SECRET_ACCESS_KEY=MY-SECRET-KEY
 
 ## Usage example:
 
+You can use either argument `-endpoint` OR environment variable `ENDPOINT` to specify AWS ElasticSearch endpoint.
+
 ```sh
 ./aws-es-proxy -endpoint https://test-es-somerandomvalue.eu-west-1.es.amazonaws.com
 Listening on 127.0.0.1:9200
+```
+
+```sh
+export ENDPOINT=https://test-es-somerandomvalue.eu-west-1.es.amazonaws.com
+
+./aws-es-proxy  -listen 10.0.0.1:9200 -verbose
+Listening on 10.0.0.1:9200
 ```
 
 *aws-es-proxy* listens on 127.0.0.1:9200 if no additional argument is provided. You can change the IP and Port passing the argument `-listen`

--- a/aws-es-proxy.go
+++ b/aws-es-proxy.go
@@ -442,10 +442,16 @@ func main() {
 	flag.StringVar(&realm, "realm", "", "Authentication Required")
 	flag.Parse()
 
-	if len(os.Args) < 2 {
-		fmt.Println("You need to specify Amazon ElasticSearch endpoint.")
-		fmt.Println("Please run with '-h' for a list of available arguments.")
-		os.Exit(1)
+	if endpoint == "" {
+		if v, ok := os.LookupEnv(strings.ToUpper("endpoint")); ok {
+			endpoint = v
+		} else {
+			text := "You need to specify Amazon ElasticSearch endpoint.\n" +
+        "You can use either argument '-endpoint' OR environment variable 'ENDPOINT'.\n" +
+        "Please run with '-h' for a list of available arguments."
+			fmt.Println(text)
+			os.Exit(1)
+		}
 	}
 
 	if debug {


### PR DESCRIPTION
Fixes #71 

Added environment variable support for elasticsearch endpoint.

`export ENDPOINT=https://test-es-somerandomvalue.eu-west-1.es.amazonaws.com`

Users can use either argument `-endpoint` OR environment variable `ENDPOINT` to specify AWS ElasticSearch endpoint. If we mention both argument and env variable then argument `-endpoint` value takes high precedence and used.