### PR TITLE
Workaround metricbeat (beats) dashboard import.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/aws/aws-sdk-go v1.30.4
 	github.com/sirupsen/logrus v1.4.2
 	go.mongodb.org/mongo-driver v1.3.1
+	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )


### PR DESCRIPTION
To import Dashboards (default) from Elastic Beats to AES (Amazon Elasticsearch), it is necessary to implement Cookie management (Security Plugin/ FGAC).
In order to make this process transparent to the client (beats), I used aws-es-proxy and implemented only cookie control so that this process is possible.

It will be of great help to users with this same need (Beats * Dashboards -> AES). 