### PR TITLE
block-deletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,12 @@ For a full list of available options, use `-h`:
 ```sh
 ./aws-es-proxy -h
 Usage of ./aws-es-proxy:
+  -assume string
+        Optionally specify role to assume
   -auth
         Require HTTP Basic Auth
+  -block-deletes
+        Block delete requests, defaults to false
   -debug
         Print debug messages
   -endpoint string

--- a/aws-es-proxy.go
+++ b/aws-es-proxy.go
@@ -88,6 +88,7 @@ type proxy struct {
 	realm           string
 	remoteTerminate bool
 	assumeRole      string
+	blockDeletes    bool
 }
 
 func newProxy(args ...interface{}) *proxy {
@@ -114,6 +115,7 @@ func newProxy(args ...interface{}) *proxy {
 		realm:           args[9].(string),
 		remoteTerminate: args[10].(bool),
 		assumeRole:      args[11].(string),
+		blockDeletes:    args[12].(bool),
 	}
 }
 
@@ -225,9 +227,18 @@ func (p *proxy) getSigner() *v4.Signer {
 	return v4.NewSigner(p.credentials)
 }
 
+func isDeletePath(path string) bool {
+	return strings.Contains(path, "_delete_by_query")
+}
+
 func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if p.remoteTerminate && r.URL.Path == "/terminate-proxy" && r.Method == http.MethodPost {
 		logrus.Infoln("Terminate Signal")
+		os.Exit(0)
+	}
+
+	if p.blockDeletes && (r.Method == http.MethodDelete || isDeletePath(r.URL.Path)) {
+		logrus.Warningln("Blocked Delete Request")
 		os.Exit(0)
 	}
 
@@ -464,6 +475,7 @@ func main() {
 		timeout         int
 		remoteTerminate bool
 		assumeRole      string
+		blockDeletes    bool
 	)
 
 	flag.StringVar(&endpoint, "endpoint", "", "Amazon ElasticSearch Endpoint (e.g: https://dummy-host.eu-west-1.es.amazonaws.com)")
@@ -481,6 +493,7 @@ func main() {
 	flag.StringVar(&realm, "realm", "", "Authentication Required")
 	flag.BoolVar(&remoteTerminate, "remote-terminate", false, "Allow HTTP remote termination")
 	flag.StringVar(&assumeRole, "assume", "", "Optionally specify role to assume")
+	flag.BoolVar(&blockDeletes, "block-deletes", false, "Block delete requests, defaults to false")
 	flag.Parse()
 
 	if endpoint == "" {
@@ -528,6 +541,7 @@ func main() {
 		realm,
 		remoteTerminate,
 		assumeRole,
+		blockDeletes,
 	)
 
 	if err = p.parseEndpoint(); err != nil {


### PR DESCRIPTION
### The Problem

I just accidentally deleted a lot of documents from a remote cluster because I forgot this tunnel was opened 🤦.


### The Solution

Add a `-block-deletes` flag which will block delete requests from being proxied through to the cluster.  I am very rarely wanting to connect to a remote cluster to do delete operations, so from now on I will use this library like so:

```
aws-es-proxy -block-deletes -endpoint http://foobar
```

The default is still to allow requests unless you opt-out using the new flag.


### Risks

1. I am not a heavy ES user so I don't think I've covered all of the possible ways to delete things.  From what I saw in the documentation disallowing `DELETE` requests is a good starting point.  I burned myself with the `_delete_by_query` functionality so I also added that one.  It won't do anything to block deletes that are in a `_bulk` query.

2. I know this isn't strictly related to proxying but I think this would be a nice option to have.


### Other

- I tested this locally using `go run aws-es-proxy.go -block-deletes -endpoint <my_endpoint>` and sent through some `DELETE` requests and some `_delete_by_query` requests, all of which were blocked with a log indicating what happened:

```
$ go run aws-es-proxy.go -block-deletes -endpoint https://myendpoint.amazonaws.com     
INFO[2021-13-07 14:48:29] Listening on 127.0.0.1:9200...               
WARN[2021-13-07 14:48:41] Blocked Delete Request   
```