### PR TITLE
Updated headers to reflect naming change from Kbn->Osd.

### DIFF
--- a/aws-es-proxy.go
+++ b/aws-es-proxy.go
@@ -413,20 +413,20 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Recent versions of ES/Kibana require
 // "content-type: application/json" and
-// either "kbn-version" or "kbn-xsrf"
+// either "osd-version" or "osd-xsrf"
 // headers to exist in the request.
 // If missing requests fails.
 func addHeaders(src, dest http.Header) {
-	if val, ok := src["Kbn-Version"]; ok {
-		dest.Add("Kbn-Version", val[0])
+	if val, ok := src["Osd-Version"]; ok {
+		dest.Add("Osd-Version", val[0])
 	}
 
 	if val, ok := src["Content-Type"]; ok {
 		dest.Add("Content-Type", val[0])
 	}
 
-	if val, ok := src["Kbn-Xsrf"]; ok {
-		dest.Add("Kbn-Xsrf", val[0])
+	if val, ok := src["Osd-Xsrf"]; ok {
+		dest.Add("Osd-Xsrf", val[0])
 	}
 
 	if val, ok := src["Authorization"]; ok {


### PR DESCRIPTION
Fixes 'Request must contain a osd-xsrf header' error:

![image](https://user-images.githubusercontent.com/10100968/138747975-b88a435c-0333-44c2-baa6-f67edd209fba.png)
