### PR TITLE
add opensearch dashboards supports

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,3 +27,4 @@ https://github.com/dlackty
 https://github.com/amcintosh
 https://github.com/valiton
 https://github.com/joshgarnett
+https://github.com/gengjie

--- a/README.md
+++ b/README.md
@@ -159,4 +159,6 @@ Usage of ./aws-es-proxy:
 
 After you run *aws-es-proxy*, you can now open your Web browser on [http://localhost:9200](http://localhost:9200). Everything should be working as you have your own instance of ElasticSearch running on port 9200.
 
-To access Kibana, use [http://localhost:9200/_plugin/kibana/app/kibana](http://localhost:9200/_plugin/kibana/app/kibana)
+To access Kibana, use [http://localhost:9200/_plugin/kibana/app/kibana](http://localhost:9200/_plugin/kibana/app/kibana).
+
+If you upgraded AWS ES to AWS OpenSearch, to access the dashboards, please use [http://localhost:9200/_dashboards/app/home#/](http://localhost:9200/_dashboards/app/home#/).

--- a/aws-es-proxy.go
+++ b/aws-es-proxy.go
@@ -415,10 +415,17 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // "content-type: application/json" and
 // either "kbn-version" or "kbn-xsrf"
 // headers to exist in the request.
+// And also versions of OpenSearch/Dashboards
+// require either "osd-version" or "osd-xsrf"
+// headers to exist in the request.
 // If missing requests fails.
 func addHeaders(src, dest http.Header) {
 	if val, ok := src["Kbn-Version"]; ok {
 		dest.Add("Kbn-Version", val[0])
+	}
+
+	if val, ok := src["Osd-Version"]; ok {
+		dest.Add("Osd-Version", val[0])
 	}
 
 	if val, ok := src["Content-Type"]; ok {
@@ -427,6 +434,10 @@ func addHeaders(src, dest http.Header) {
 
 	if val, ok := src["Kbn-Xsrf"]; ok {
 		dest.Add("Kbn-Xsrf", val[0])
+	}
+
+	if val, ok := src["Osd-Xsrf"]; ok {
+		dest.Add("Osd-Xsrf", val[0])
 	}
 
 	if val, ok := src["Authorization"]; ok {


### PR DESCRIPTION
**Background**: Since AWS has released OpenSearch service, which is ready to be the successor of ElasticSearch in the feature, aws-es-proxy should also support OpenSearch.

**Issue**: To apply the current version to be the proxy of OpenSearch, we encountered such issue like "Request must contain a osd-xsrf header" when trying to access the dashboard of OpenSearch.

**Solution**:  It's quite easy to add 2 header fields - "osd-version" and "osd-xsrf" to transfer between requests. You can look int details in the codes.